### PR TITLE
Add cat food page with Firestore integration

### DIFF
--- a/petme/firebase.json
+++ b/petme/firebase.json
@@ -1,10 +1,9 @@
 {
   "hosting": {
     "public": "build",
-    "ignore": [
-      "firebase.json",
-      "**/.*",
-      "**/node_modules/**"
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [
+      { "source": "**", "destination": "/index.html" }
     ]
   }
 }

--- a/petme/src/App.js
+++ b/petme/src/App.js
@@ -3,20 +3,22 @@ import React from "react";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import Menu from "./Frontend/Menu";
 import Hypernav from "./Frontend/Hypernav";
-import Slideshow from "./Frontend/Slideshow";
-import Products from "./Frontend/Products";
-
+import CatFood from "./Frontend/CatFood";
+// import AdminProductForm from "./Frontend/AdminProductForm";
 function App() {
   return (
     <Router>
       <Hypernav />
-      
       <Routes>
         <Route path="/" element={<Menu />} />
-        {/* other routes can go here */}
+        {/* match the menu link exactly */}
+        <Route path="/cats/food" element={<CatFood />} />
+        {/* <Route path="/admin" element={<AdminProductForm />} /> */}
       </Routes>
     </Router>
   );
 }
 
 export default App;
+
+

--- a/petme/src/Frontend/AdminProductionForm.jsx
+++ b/petme/src/Frontend/AdminProductionForm.jsx
@@ -1,0 +1,79 @@
+import React, { useState } from "react";
+import { db, storage } from "../firebase";
+import { addDoc, collection, serverTimestamp } from "firebase/firestore";
+import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
+
+const AdminProductForm = () => {
+  const [form, setForm] = useState({
+    title: "",
+    brand: "",
+    price: "",
+    lifeStage: "Ενήλικη",
+    type: "Ξηρά",
+    rating: 4.8,
+    category: "cat-food",
+    active: true,
+  });
+  const [file, setFile] = useState(null);
+  const [saving, setSaving] = useState(false);
+
+  const onChange = (e) => setForm({ ...form, [e.target.name]: e.target.value });
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    if (!file) return alert("Διάλεξε εικόνα προϊόντος.");
+
+    setSaving(true);
+    try {
+      // 1) ανέβασμα εικόνας
+      const filename = `products/${Date.now()}-${file.name}`;
+      const fileRef = ref(storage, filename);
+      await uploadBytes(fileRef, file);
+      const imageUrl = await getDownloadURL(fileRef);
+
+      // 2) αποθήκευση εγγράφου
+      await addDoc(collection(db, "products"), {
+        ...form,
+        price: Number(form.price),
+        rating: Number(form.rating),
+        imageUrl,
+        createdAt: serverTimestamp(),
+      });
+
+      alert("Το προϊόν καταχωρήθηκε!");
+      setForm({
+        title: "", brand: "", price: "", lifeStage: "Ενήλικη", type: "Ξηρά",
+        rating: 4.8, category: "cat-food", active: true,
+      });
+      setFile(null);
+    } catch (err) {
+      console.error(err);
+      alert("Κάτι πήγε στραβά.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form onSubmit={onSubmit} style={{ background:"#fff", padding:16, borderRadius:12 }}>
+      <h3>Νέο προϊόν</h3>
+
+      <input name="title" placeholder="Τίτλος" value={form.title} onChange={onChange} required />
+      <input name="brand" placeholder="Μάρκα" value={form.brand} onChange={onChange} required />
+      <input name="price" type="number" step="0.01" placeholder="Τιμή" value={form.price} onChange={onChange} required />
+      <select name="lifeStage" value={form.lifeStage} onChange={onChange}>
+        <option>Γατάκι</option><option>Ενήλικη</option><option>Ηλικιωμένη</option>
+      </select>
+      <select name="type" value={form.type} onChange={onChange}>
+        <option>Ξηρά</option><option>Υγρή</option>
+      </select>
+      <input name="rating" type="number" step="0.1" min="0" max="5" value={form.rating} onChange={onChange} />
+      <input name="category" value={form.category} onChange={onChange} />
+      <label>Εικόνα: <input type="file" accept="image/*" onChange={(e)=>setFile(e.target.files[0])} /></label>
+
+      <button disabled={saving} type="submit">{saving ? "Αποθήκευση..." : "Αποθήκευση"}</button>
+    </form>
+  );
+};
+
+export default AdminProductForm;

--- a/petme/src/Frontend/CatFood.css
+++ b/petme/src/Frontend/CatFood.css
@@ -1,0 +1,189 @@
+/* Layout wrapper under fixed navbar */
+.cat-page {
+  padding-top: 140px; /* navbar at 70px + hypernav offset ~70px */
+  max-width: 1200px;
+  margin: 0 auto;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+/* Breadcrumbs */
+.breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #2c3e50;
+  margin-bottom: 14px;
+  font-size: 0.95rem;
+}
+.breadcrumbs a {
+  color: #3498db;
+  text-decoration: none;
+}
+.breadcrumbs a:hover { text-decoration: underline; }
+
+/* Hero */
+.cat-hero {
+  background: linear-gradient(0deg, rgba(0,0,0,0.25), rgba(0,0,0,0.25)),
+              url("https://images.unsplash.com/photo-1573865526739-10659fec78a5?q=80&w=1600&auto=format&fit=crop") center/cover no-repeat;
+  height: 220px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  margin-bottom: 24px;
+  box-shadow: 0 4px 14px rgba(0,0,0,0.08);
+}
+.cat-hero .hero-text { text-align: center; color: #fff; }
+.cat-hero h1 { font-size: 2rem; letter-spacing: 0.3px; }
+.cat-hero p { opacity: 0.95; margin-top: 6px; }
+
+/* Two-column layout */
+.cat-layout {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 22px;
+}
+
+/* Sidebar filters */
+.filters {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.06);
+  position: sticky;
+  top: 120px;
+  height: fit-content;
+}
+.filters h2 {
+  font-size: 1.1rem;
+  color: #2c3e50;
+  margin-bottom: 10px;
+}
+.filter-label {
+  display: block;
+  font-size: 0.9rem;
+  margin-top: 10px;
+  margin-bottom: 6px;
+  color: #34495e;
+}
+.filters select {
+  width: 100%;
+  height: 40px;
+  border-radius: 10px;
+  border: 1px solid #e3e6ea;
+  padding: 0 10px;
+  outline: none;
+}
+.btn-clear {
+  margin-top: 12px;
+  width: 100%;
+  height: 40px;
+  border-radius: 20px;
+  border: 1px solid #00B9A6;
+  background: #fff;
+  color: #00B9A6;
+  cursor: pointer;
+}
+.btn-clear:hover { background: #eafffb; }
+
+/* Results */
+.results .results-header {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 12px 14px;
+  margin-bottom: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.06);
+}
+.results .chip {
+  background: #eafffb;
+  color: #00B9A6;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+}
+.sort-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.sort-group select {
+  height: 36px; border-radius: 8px; border: 1px solid #e3e6ea; padding: 0 8px;
+}
+
+/* Grid */
+.product-grid {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+.product-card {
+  background: #ffffff;
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.06);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.product-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(0,0,0,0.1);
+}
+.product-card img {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  display: block;
+}
+.card-link { text-decoration: none; color: inherit; display: block; }
+.card-body { padding: 12px; }
+.card-body .title { font-size: 1.05rem; line-height: 1.35; }
+.card-body .meta { color: #6b7b8c; margin: 6px 0 10px; font-size: 0.9rem; }
+.price-row { display: flex; align-items: center; justify-content: space-between; }
+.price { font-weight: 700; color: #2c3e50; }
+.rating { font-size: 0.9rem; color: #34495e; }
+.btn-primary {
+  margin-top: 10px;
+  width: 100%;
+  height: 40px;
+  border: none;
+  border-radius: 10px;
+  background: #00B9A6;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+.btn-primary:hover { background: #02a090; }
+
+/* Pagination */
+.pagination {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  justify-content: center;
+  margin: 18px 0 10px;
+}
+.page-btn {
+  height: 38px;
+  padding: 0 14px;
+  border-radius: 10px;
+  border: 1px solid #e3e6ea;
+  background: #fff;
+  cursor: pointer;
+}
+.page-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.page-info { color: #34495e; }
+
+/* Responsive */
+@media (max-width: 1024px) {
+  .product-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+@media (max-width: 768px) {
+  .cat-layout { grid-template-columns: 1fr; }
+  .filters { position: static; }
+  .cat-page { padding-top: 120px; }
+  .product-grid { grid-template-columns: 1fr; }
+}
+

--- a/petme/src/Frontend/CatFood.jsx
+++ b/petme/src/Frontend/CatFood.jsx
@@ -1,0 +1,325 @@
+import React, { useState, useEffect, useRef } from "react";
+import { Link } from "react-router-dom";
+import { collection, query, where, orderBy, getDocs } from "firebase/firestore";
+import { db } from "../firebase"; // προσαρμόζεις το path
+import "./CatFood.css";
+import Footer from "./Footer";
+
+const Navbar = () => {
+  const [menuActive, setMenuActive] = useState(false);
+  const [openDropdownIndex, setOpenDropdownIndex] = useState(null);
+  const hamburgerRef = useRef(null);
+
+  const toggleMenu = () => {
+    setMenuActive((prev) => !prev);
+    if (menuActive) setOpenDropdownIndex(null);
+  };
+
+  const toggleDropdown = (idx) => {
+    setOpenDropdownIndex((prev) => (prev === idx ? null : idx));
+  };
+
+  const handleLinkClick = () => {
+    if (window.innerWidth <= 768) {
+      setMenuActive(false);
+      setOpenDropdownIndex(null);
+    }
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      toggleMenu();
+    }
+  };
+
+  useEffect(() => {
+    if (hamburgerRef.current) {
+      hamburgerRef.current.setAttribute("aria-expanded", menuActive);
+    }
+  }, [menuActive]);
+
+  const greekMenuItems = [
+    { label: "Αρχική", isHome: true, submenu: [] },
+    {
+      label: "Σκυλιά",
+      isHome: false,
+      submenu: [
+        { label: "Τροφές", href: "#dog-food" },
+        { label: "Αξεσουάρ", href: "#dog-accessories" },
+      ],
+    },
+    {
+      label: "Γάτες",
+      isHome: false,
+      submenu: [
+        { label: "Τροφές", href: "/cats/food", active: true },
+        { label: "Παιχνίδια", href: "#cat-toys" },
+      ],
+      activeParent: true,
+    },
+    {
+      label: "Πτηνά",
+      isHome: false,
+      submenu: [
+        { label: "Κλουβιά", href: "#bird-cages" },
+        { label: "Τροφές", href: "#bird-food" },
+      ],
+    },
+    {
+      label: "Υπηρεσίες",
+      isHome: false,
+      submenu: [
+        { label: "Κτηνίατροι", href: "#vets" },
+        { label: "Φροντίδα", href: "#care" },
+      ],
+    },
+  ];
+
+  return (
+    <header className="navbar">
+      <div className="logo">
+        <Link to="/">PetME</Link>
+      </div>
+
+      <nav className={`nav-menu ${menuActive ? "active" : ""}`} id="nav-menu">
+        <ul className="nav-links">
+          {greekMenuItems.map((item, idx) => {
+            const hasSubmenu = item.submenu.length > 0;
+            const isOpen = openDropdownIndex === idx;
+
+            return (
+              <li
+                key={idx}
+                className={`has-dropdown ${isOpen ? "open" : ""} ${item.isHome ? "no-arrow" : ""}`}
+                onClick={() => {
+                  if (window.innerWidth <= 768 && hasSubmenu) {
+                    toggleDropdown(idx);
+                  }
+                }}
+              >
+                <a
+                  href="#"
+                  onClick={(e) => {
+                    if (window.innerWidth <= 768 && hasSubmenu) {
+                      e.preventDefault();
+                      toggleDropdown(idx);
+                    } else {
+                      handleLinkClick();
+                    }
+                  }}
+                  className={item.activeParent ? "active" : item.isHome ? "active" : ""}
+                  aria-haspopup={hasSubmenu ? "true" : undefined}
+                  aria-expanded={isOpen ? "true" : "false"}
+                  tabIndex="0"
+                >
+                  {item.label}
+                </a>
+
+                {hasSubmenu && (
+                  <ul className="dropdown">
+                    {item.submenu.map((subItem, subIdx) => (
+                      <li key={subIdx}>
+                        {subItem.href.startsWith("/") ? (
+                          <Link
+                            to={subItem.href}
+                            onClick={handleLinkClick}
+                            className={subItem.active ? "active" : ""}
+                            aria-current={subItem.active ? "page" : undefined}
+                          >
+                            {subItem.label}
+                          </Link>
+                        ) : (
+                          <a
+                            href={subItem.href}
+                            onClick={handleLinkClick}
+                            className={subItem.active ? "active" : ""}
+                            aria-current={subItem.active ? "page" : undefined}
+                          >
+                            {subItem.label}
+                          </a>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+
+      <div className="nav-center-right">
+        <form className="search-bar" onSubmit={(e) => e.preventDefault()}>
+          <input type="text" placeholder="Αναζήτηση..." aria-label="Search" />
+          <button type="submit" aria-label="Search button">🔍</button>
+        </form>
+
+        <div
+          className={`hamburger ${menuActive ? "active" : ""}`}
+          onClick={toggleMenu}
+          onKeyDown={handleKeyDown}
+          ref={hamburgerRef}
+          role="button"
+          tabIndex="0"
+          aria-label="Toggle navigation menu"
+          aria-controls="nav-menu"
+          aria-expanded={menuActive}
+        >
+          <span className="bar"></span>
+          <span className="bar"></span>
+          <span className="bar"></span>
+        </div>
+      </div>
+    </header>
+  );
+};
+
+const CatFood = () => {
+  const [products, setProducts] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+  const loadProducts = async () => {
+    try {
+      // 1) Δοκίμασε σκέτο, να δούμε ΟΤΙ διαβάζει από Firestore
+      // const snapAll = await getDocs(collection(db, "products"));
+      // console.log("ALL PRODUCTS:", snapAll.docs.map(d => ({ id: d.id, ...d.data() })));
+
+      // 2) Query με φίλτρα, χωρίς orderBy (για να αποκλείσουμε θέμα index/createdAt)
+      const qNoOrder = query(
+        collection(db, "products"),
+        where("category", "==", "cat-food"),
+        where("active", "==", true)
+      );
+
+      let snap = await getDocs(qNoOrder);
+      let rows = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+      console.log("CAT-FOOD (no order):", rows);
+
+      // 3) Αν πήραμε αποτελέσματα και ΟΛΑ έχουν createdAt, προσπάθησε και με orderBy
+      const allHaveCreatedAt = rows.length > 0 && rows.every(r => !!r.createdAt);
+      if (allHaveCreatedAt) {
+        try {
+          const qWithOrder = query(
+            collection(db, "products"),
+            where("category", "==", "cat-food"),
+            where("active", "==", true),
+            orderBy("createdAt", "desc")
+          );
+          snap = await getDocs(qWithOrder);
+          rows = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+          console.log("CAT-FOOD (with order):", rows);
+        } catch (orderErr) {
+          // Αν ζητά index, θα δεις link στην κονσόλα — κλίκαρέ το και φτιάξ’ το.
+          console.warn("orderBy failed, using no-order results. Details:", orderErr);
+        }
+      }
+
+      setProducts(rows);
+    } catch (err) {
+      console.error("Firestore error:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+  loadProducts();
+}, []);
+
+  return (
+    <>
+      <Navbar />
+
+      <main id="cat-food" style={{ paddingTop: 140, maxWidth: 1200, margin: "0 auto", paddingLeft: 16, paddingRight: 16 }}>
+        <nav className="breadcrumbs" aria-label="Θέση στη σελίδα" style={{ display: "flex", gap: 8, marginBottom: 14 }}>
+          <Link to="/">Αρχική</Link>
+          <span aria-hidden="true">›</span>
+          <span>Γάτες</span>
+          <span aria-hidden="true">›</span>
+          <span aria-current="page">Τροφές</span>
+        </nav>
+
+        <section
+          className="cat-hero"
+          role="img"
+          aria-label="Τροφές γάτας"
+          style={{
+            background:
+              "linear-gradient(0deg, rgba(0,0,0,0.25), rgba(0,0,0,0.25)), url('https://images.unsplash.com/photo-1573865526739-10659fec78a5?q=80&w=1600&auto=format&fit=crop') center/cover no-repeat",
+            height: 220,
+            borderRadius: 14,
+            display: "grid",
+            placeItems: "center",
+            marginBottom: 24,
+            color: "#fff",
+            textAlign: "center",
+          }}
+        >
+          <div>
+            <h1>Τροφές Γάτας</h1>
+            <p style={{ opacity: 0.95, marginTop: 6 }}>
+              Ξηρά, υγρή και ειδικές συνταγές — ενημερώνονται αυτόματα από Firebase.
+            </p>
+          </div>
+        </section>
+
+        {loading ? (
+          <p>Φόρτωση…</p>
+        ) : products.length === 0 ? (
+          <p>Δεν υπάρχουν προϊόντα.</p>
+        ) : (
+          <ul className="product-grid">
+            {products.map((p) => (
+            <li key={p.id} className="product-card">
+  <a className="card-link" href={`#/product/${p.id}`}>
+    <img src={p.imageUrl} alt={p.title} loading="lazy" />
+    <div className="card-body">
+      <h3 className="title">{p.title}</h3>
+      <p className="meta">
+        <span>{p.brand}</span> · <span>{p.lifeStage}</span> · <span>{p.type}</span>
+      </p>
+
+      {/* --- STOCK BADGE --- */}
+      {(() => {
+        const stock = Number(p.stock ?? 0);
+        const stockClass = stock <= 0 ? "stock-out" : stock <= 5 ? "stock-low" : "stock-in";
+        const stockLabel =
+          stock <= 0 ? "Εξαντλημένο" : stock <= 5 ? `Λίγα τεμάχια (${stock})` : `Σε απόθεμα (${stock})`;
+        return <span className={`stock-badge ${stockClass}`}>{stockLabel}</span>;
+      })()}
+
+      <div className="price-row" style={{ marginTop: 8 }}>
+        <span className="price">€{Number(p.price).toFixed(2)}</span>
+        {p.rating && <span className="rating">★ {p.rating}</span>}
+      </div>
+
+      {(() => {
+        const stock = Number(p.stock ?? 0);
+        const disabled = stock <= 0;
+        return (
+          <button
+            className={`btn-primary ${disabled ? "btn-disabled" : ""}`}
+            type="button"
+            disabled={disabled}
+            aria-disabled={disabled}
+            title={disabled ? "Μη διαθέσιμο προς το παρόν" : "Προσθήκη στο καλάθι"}
+          >
+            {disabled ? "Εξαντλημένο" : "Προσθήκη στο καλάθι"}
+          </button>
+        );
+      })()}
+    </div>
+  </a>
+</li>
+
+            ))}
+          </ul>
+        )}
+      </main>
+
+      <Footer />
+    </>
+  );
+};
+
+export default CatFood;

--- a/petme/src/Frontend/Menu.css
+++ b/petme/src/Frontend/Menu.css
@@ -274,4 +274,23 @@ body {
     width: 200px;
     max-width: 70vw;
   }
+
+  /* Stock badges */
+.stock-badge {
+  display: inline-block;
+  margin: 6px 0 0;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+.stock-in  { background: #eafffb; color: #00B9A6; }    /* ταιριάζει με την παλέτα σου */
+.stock-low { background: #fff5e6; color: #b66a00; }
+.stock-out { background: #f1f2f6; color: #6b7b8c; }
+
+.btn-disabled {
+  background: #cbd5e1 !important;
+  cursor: not-allowed !important;
+}
+
 }

--- a/petme/src/Frontend/Menu.jsx
+++ b/petme/src/Frontend/Menu.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
+import { Link } from "react-router-dom"; // <-- add this
 import "./Menu.css";
 import Hypernav from "../Frontend/Hypernav";
 import Slideshow from "./Slideshow";
@@ -12,10 +13,7 @@ const Menu = () => {
 
   const toggleMenu = () => {
     setMenuActive((prev) => !prev);
-    // Close any open dropdown when menu toggles
-    if (menuActive) {
-      setOpenDropdownIndex(null);
-    }
+    if (menuActive) setOpenDropdownIndex(null);
   };
 
   const toggleDropdown = (idx) => {
@@ -56,7 +54,7 @@ const Menu = () => {
       label: "Γάτες",
       isHome: false,
       submenu: [
-        { label: "Τροφές", href: "#cat-food" },
+        { label: "Τροφές", href: "/cats/food" }, // must match your Route
         { label: "Παιχνίδια", href: "#cat-toys" },
       ],
     },
@@ -84,7 +82,7 @@ const Menu = () => {
 
       <header className="navbar">
         <div className="logo">
-          <a href="/">PetME</a>
+          <Link to="/">PetME</Link>
         </div>
 
         <nav className={`nav-menu ${menuActive ? "active" : ""}`} id="nav-menu">
@@ -103,11 +101,12 @@ const Menu = () => {
                     }
                   }}
                 >
+                  {/* Parent label (desktop hover; mobile toggles dropdown) */}
                   <a
                     href="#"
                     onClick={(e) => {
                       if (window.innerWidth <= 768 && hasSubmenu) {
-                        e.preventDefault(); // prevent navigation on mobile for parent menu with submenu
+                        e.preventDefault();
                         toggleDropdown(idx);
                       } else {
                         handleLinkClick();
@@ -121,13 +120,20 @@ const Menu = () => {
                     {item.label}
                   </a>
 
+                  {/* Submenu */}
                   {hasSubmenu && (
                     <ul className="dropdown">
                       {item.submenu.map((subItem, subIdx) => (
                         <li key={subIdx}>
-                          <a href={subItem.href} onClick={handleLinkClick}>
-                            {subItem.label}
-                          </a>
+                          {subItem.href.startsWith("/") ? (
+                            <Link to={subItem.href} onClick={handleLinkClick}>
+                              {subItem.label}
+                            </Link>
+                          ) : (
+                            <a href={subItem.href} onClick={handleLinkClick}>
+                              {subItem.label}
+                            </a>
+                          )}
                         </li>
                       ))}
                     </ul>
@@ -162,7 +168,6 @@ const Menu = () => {
         </div>
       </header>
 
-      {/* Add Slideshow below navbar */}
       <Slideshow />
       <Products />
       <Footer />


### PR DESCRIPTION
Introduces a new CatFood page that displays cat food products from Firestore, including a dedicated route and menu link. Adds CatFood.jsx and CatFood.css for layout and styling, updates the main menu to use React Router's Link, and implements stock badges and disabled button states. Also adds an admin product form (AdminProductionForm.jsx) for product entry and configures Firebase hosting rewrites for SPA routing.